### PR TITLE
Update buildspec.yaml

### DIFF
--- a/buildspec.yaml
+++ b/buildspec.yaml
@@ -4,8 +4,8 @@ phases:
   install:
     commands:
       - echo installing nodejs...
-      - curl -sL https://deb.nodesource.com/setup_12.x | bash -
-      - apt-get install -y nodejs  #aws code build use ubuntu environement
+      - curl -sL https://deb.nodesource.com/setup_16.x | bash -
+      - apt-get install -y nodejs  #aws code build use ubuntu environement and image aws/codebuild/standard:6.0
   pre_build:
     commands:
       - echo installing dependencies...


### PR DESCRIPTION
Updated Node.js to 16.x I also added to the comment about using ubuntu, "and image aws/codebuild/standard:6.0"

The optional LUIT CI/CD project still works with the node.js update.